### PR TITLE
Fix ios run hook when version number differs from 1 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ android/assets
 android/LICENSE
 iphone/build/
 build.log
+.idea/.name
+.idea/encodings.xml
+.idea/fabric-manojdcoder.iml
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml
+.idea/workspace.xml

--- a/plugins/ti.fabric/cli/hooks/run.js
+++ b/plugins/ti.fabric/cli/hooks/run.js
@@ -36,12 +36,12 @@ exports.init = function(logger, config, cli, appc) {
 
 					try {
 
-						logger.debug(TAG + ' : ' + ' processing fabric for ios');
+						logger.debug(TAG + ' : ' + ' processing fabric for ios - version ' + VERSION);
 
 						var pbxprojPath = projectDir + '/build/iphone/' + cli.tiapp.name + '.xcodeproj/project.pbxproj',
 						    pbxprojStr = fs.readFileSync(pbxprojPath).toString(),
 						    sectionName = 'Post-Compile',
-						    shellScript = '\\nchmod 755 ../../modules/iphone/ti.fabric/' + VERSION + '/platform/Fabric.framework/run\\n../../modules/iphone/ti.fabric/1.0/platform/Fabric.framework/run ' + (cli.argv['fabric-key'] || API_KEY) + ' ' + (cli.argv['fabric-secret'] || API_SECRET);
+						    shellScript = '\\nchmod 755 ../../modules/iphone/ti.fabric/' + VERSION + '/platform/Fabric.framework/run\\n../../modules/iphone/ti.fabric/' + VERSION + '/platform/Fabric.framework/run ' + (cli.argv['fabric-key'] || API_KEY) + ' ' + (cli.argv['fabric-secret'] || API_SECRET);
 
 						var p = 0;
 						while (p !== -1) {


### PR DESCRIPTION
The run hook contained a hardcoded version. Removed it and made it version-dependant
