### PR TITLE
Fix ios run hook add shellscript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ android/assets
 android/LICENSE
 iphone/build/
 build.log
+.idea/.name
+.idea/encodings.xml
+.idea/fabric-manojdcoder.iml
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml
+.idea/workspace.xml

--- a/plugins/ti.fabric/cli/hooks/run.js
+++ b/plugins/ti.fabric/cli/hooks/run.js
@@ -32,26 +32,61 @@ exports.init = function(logger, config, cli, appc) {
 
 			cli.on('build.ios.xcodebuild', {
 
+
 				pre : function(build, done) {
+
+					logger.debug('executing build.ios.xcodebuild pre hook');
 
 					try {
 
-						logger.debug(TAG + ' : ' + ' processing fabric for ios');
+						logger.debug(TAG + ' : ' + ' processing fabric for ios - version ' + VERSION);
 
 						var pbxprojPath = projectDir + '/build/iphone/' + cli.tiapp.name + '.xcodeproj/project.pbxproj',
-						    pbxprojStr = fs.readFileSync(pbxprojPath).toString(),
-						    sectionName = 'Post-Compile',
-						    shellScript = '\\nchmod 755 ../../modules/iphone/ti.fabric/' + VERSION + '/platform/Fabric.framework/run\\n../../modules/iphone/ti.fabric/1.0/platform/Fabric.framework/run ' + (cli.argv['fabric-key'] || API_KEY) + ' ' + (cli.argv['fabric-secret'] || API_SECRET);
+							pbxprojStr = fs.readFileSync(pbxprojPath).toString(),
+							shellScript = '\\nchmod 755 ../../modules/iphone/ti.fabric/' + VERSION + '/platform/Fabric.framework/run\\n../../modules/iphone/ti.fabric/' + VERSION + '/platform/Fabric.framework/run ' + (cli.argv['fabric-key'] || API_KEY) + ' ' + (cli.argv['fabric-secret'] || API_SECRET);
 
+						var OUR_UNIQUE_KEY = '636363C2C2C2C2C2C2C2C2C2';
 						var p = 0;
-						while (p !== -1) {
-							p = pbxprojStr.indexOf('name = "' + sectionName + '"', p);
-							if (p !== -1) {
-								p = pbxprojStr.indexOf('shellScript = ', p);
-								if (p !== -1) {
-									pbxprojStr = pbxprojStr.substring(0, p) + 'shellScript = "' + pbxprojStr.substring(p + 'shellScript = '.length + 1, pbxprojStr.indexOf('\n', p) - 2) + shellScript + '";' + pbxprojStr.substring(pbxprojStr.indexOf('\n', p));
+
+						p = pbxprojStr.indexOf('Begin PBXNativeTarget section', p);
+
+						if(p !== -1){
+							var endPbxNativeTargetSectionIndex = pbxprojStr.indexOf('End PBXNativeTarget section', p);
+
+							p = pbxprojStr.indexOf('buildPhases', p);
+							if(p !== -1 && p < endPbxNativeTargetSectionIndex){
+								logger.debug('adding the build phase');
+
+								var targetClosingBracketIndex = pbxprojStr.indexOf(');', p);
+								pbxprojStr = pbxprojStr.substring(0, targetClosingBracketIndex-1) + OUR_UNIQUE_KEY + ' /* ShellScript */, \n' + pbxprojStr.substring(targetClosingBracketIndex);
+
+								// okay, now add the script
+								p = pbxprojStr.indexOf('/* End PBXShellScriptBuildPhase section */', p);
+
+								if(p == -1){
+									throw 'no PBXShellScriptBuildPhase section found'
 								}
+
+								var shellScriptSection = '\n' + OUR_UNIQUE_KEY + ' /* ShellScript */ = {\n' +
+									'isa = PBXShellScriptBuildPhase;\n' +
+									'buildActionMask = 2147483647;\n' +
+									'files = (\n' +
+									');\n' +
+									'inputPaths = (\n' +
+									');\n' +
+									'outputPaths = (\n' +
+									');\n' +
+									'runOnlyForDeploymentPostprocessing = 0;\n' +
+									'shellPath = /bin/sh;\n' +
+									'shellScript = "' + shellScript + '";\n};\n' ;
+
+								pbxprojStr = pbxprojStr.substring(0, p-1) + shellScriptSection + pbxprojStr.substring(p);
+
+							} else {
+								throw 'no PBXProject.targets found';
 							}
+						} else {
+							throw 'no PBXProject section found. Operation aborted.';
 						}
 
 						fs.writeFileSync(pbxprojPath, pbxprojStr);
@@ -79,10 +114,10 @@ exports.init = function(logger, config, cli, appc) {
 						logger.debug(TAG + ' : ' + ' processing fabric for android');
 
 						var buildDir = projectDir + '/build/android/',
-						    srcFabricProperties = projectDir + '/plugins/ti.fabric/android/fabric.properties',
-						    srcKitsProperties = projectDir + '/plugins/ti.fabric/android/kits.properties',
-						    srcCustomRules = projectDir + '/plugins/ti.fabric/android/custom_rules.xml',
-						    srcCrashlyticsFld = projectDir + '/plugins/ti.fabric/android/crashlytics';
+							srcFabricProperties = projectDir + '/plugins/ti.fabric/android/fabric.properties',
+							srcKitsProperties = projectDir + '/plugins/ti.fabric/android/kits.properties',
+							srcCustomRules = projectDir + '/plugins/ti.fabric/android/custom_rules.xml',
+							srcCrashlyticsFld = projectDir + '/plugins/ti.fabric/android/crashlytics';
 
 						fs.writeFileSync(buildDir + 'fabric.properties', fs.readFileSync(srcFabricProperties).toString().replace("API_SECRET", (cli.argv['fabric-secret'] || API_SECRET)));
 
@@ -105,6 +140,8 @@ exports.init = function(logger, config, cli, appc) {
 
 		}
 
+	} else {
+		logger.error('Fabric not enabled for this build');
 	}
 
 };


### PR DESCRIPTION
Hello,

We had trouble getting the shellScript running. After some investigation, we found out there was no 'Post-Compile' phase defined in our _project.pbxproj_. Because of that, the shellScript was not added to our _project.pbxproj_ and the dSYM was not uploaded to the Fabric.io backend.

Therefore, we have rewritten the code which alters the _project.pbxproj_ and now everything works fine. However, we guess the previous version of the script must have worked in the past, thus we are not sure we can simply override it by this version. Can you verify if our new version of the script doesn't break things.

For the sake of completeness, I have also added the steps we execute to register an app for the 1st time:
- Download fabric mac app (https://fabric.io/downloads/apple)
- Add new project
- Build your app via CLI: appc run --platform ios -T device --fabric-enabled true --log-level debug
- Select your Xcode Project (appear after building your appcelerator app for ios)
- Select the organization
- At Crashlytics, click "install"
- Don't follow the instruction on that window, instead:
- Build your app via CLI: appc run --platform ios -T device --fabric-enabled true --log-level debug
- After a few seconds, the Fabric app will navigate to the next window
- Don't follow the instructions on that window, instead:
- Build your app via CLI: appc run --platform ios -T device --fabric-enabled true --log-level debug
- After a few seconds, the Fabric app will show the "Done" button
- Now click the "Done" button
- Verify your OSX Console, check for the uploading dSYM eg. : 7/10/16 09:56:48,520 uploadDSYM[51191]: Uploading dSYM . If you don't find a similar message, please search the CLI console for TiFabric
- Go to the Fabric.io website and verify if your app has been added

Kind regards,
David
